### PR TITLE
Fixes .get()'s return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -109,7 +109,6 @@ declare namespace cheerio {
 
     eq(index: number): Cheerio;
 
-    get(): string[];
     get(): Element[];
     get(index: number): Element;
 
@@ -272,4 +271,4 @@ declare namespace cheerio {
 declare function cheerio(selector: string, context: string ): cheerio.Cheerio;
 declare function cheerio(selector: string, context: string, root: string): cheerio.Cheerio;
 
-export = cheerio
+export = cheerio;

--- a/test/test.ts
+++ b/test/test.ts
@@ -16,3 +16,20 @@ test( 'Simple html check', function(t) {
   return t.end();
 });
 
+test( '#get()', function(t) {
+  const $ = cheerio.load('<ul> <li></li> <li></li> </ul>');
+  let $ul: cheerio.Cheerio = $('ul');
+  let $lis: cheerio.Cheerio = $('li');
+
+  let lis: cheerio.Element[] = $lis.get();
+  t.equal( lis.length, 2, 'Got the right number of elements' );
+  t.assert( lis instanceof Array, 'Result was an Array' );
+  t.equal( lis[0].tagName, 'li', 'First element has the correct tagName' );
+  t.equal( lis[1].tagName, 'li', 'Second element has the correct tagName' );
+
+  let ul: cheerio.Element = $ul.get(0);
+  t.equal( lis[0].parent, ul, 'First element has the correct parent' );
+  t.equal( lis[1].parent, ul, 'Second element has the correct parent' );
+
+  return t.end();
+});


### PR DESCRIPTION
Removes the override for `.get()` whose return type is `string[]`. According to the [cheerio
 docs](https://github.com/cheeriojs/cheerio#get-i-), `get()` returns an  `Array` of `Elements` as in the other typings, so I removed the erroneous one and added a test for this case.
