### PR TITLE
Add override for `load` that takes an `Element`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -267,6 +267,7 @@ declare namespace cheerio {
   }
 
   export function load(html: string, options?: Options): Static;
+  export function load(element: Element, options?: Options): Static;
 }
 
 declare function cheerio(selector: string, context: string ): cheerio.Cheerio;


### PR DESCRIPTION
This usage of cheerio is valid.

``` javascript
const html = "<a href='1'>1</a><a href='2'>2</a><a href='3'>3</a>";
const $ = cheerio.load(html);
$('a').each((idx, element) => {
  const a = cheerio.load(element);
  const href = a('[href]').attr('href');
  console.log(href);
});
```

This additional override for the `load` function ensures that it passes type checking.
